### PR TITLE
CTCP-4002: Add invalid guarantee type to the stub, move some matches into the controller for ease of use

### DIFF
--- a/app/uk/gov/hmrc/ctcguaranteebalanceeisstub/models/GuaranteeReferenceNumber.scala
+++ b/app/uk/gov/hmrc/ctcguaranteebalanceeisstub/models/GuaranteeReferenceNumber.scala
@@ -18,14 +18,7 @@ package uk.gov.hmrc.ctcguaranteebalanceeisstub.models
 
 import play.api.libs.json._
 
-case class GuaranteeReferenceNumber(value: String) extends AnyVal {
-
-  // we consider all GRNs starting with "1" as not found in the DB
-  def isValid: Boolean = value match {
-    case GuaranteeReferenceNumber.grnPattern(_) => !value.startsWith("1")
-    case _                                      => false
-  }
-}
+case class GuaranteeReferenceNumber(value: String) extends AnyVal
 
 object GuaranteeReferenceNumber {
   val grnPattern = """[0-9]{2}[A-Z]{2}[A-Z0-9]{12}[0-9]([A-Z][0-9]{6})?""".r

--- a/app/uk/gov/hmrc/ctcguaranteebalanceeisstub/models/requests/AccessCodeRequest.scala
+++ b/app/uk/gov/hmrc/ctcguaranteebalanceeisstub/models/requests/AccessCodeRequest.scala
@@ -19,9 +19,7 @@ package uk.gov.hmrc.ctcguaranteebalanceeisstub.models.requests
 import play.api.libs.json.Json
 import uk.gov.hmrc.ctcguaranteebalanceeisstub.models.AccessCode
 
-case class AccessCodeRequest(masterAccessCode: AccessCode) {
-  val isValidAccessCode = masterAccessCode.value == AccessCode.constantAccessCodeValue.value
-}
+case class AccessCodeRequest(masterAccessCode: AccessCode)
 
 object AccessCodeRequest {
   implicit val format = Json.format[AccessCodeRequest]

--- a/app/uk/gov/hmrc/ctcguaranteebalanceeisstub/models/responses/RequestErrorResponse.scala
+++ b/app/uk/gov/hmrc/ctcguaranteebalanceeisstub/models/responses/RequestErrorResponse.scala
@@ -37,8 +37,11 @@ object RequestErrorResponse {
       (JsPath \ "timestamp").write[String] and
       (JsPath \ "path").write[String])(unlift(RequestErrorResponse.unapply))
 
-  def invalidAccessCode = RequestErrorResponse("Not Valid Access Code for this operation", "2023-01-24T11:57:36.0537863801", "...")
+  val invalidAccessCode = RequestErrorResponse("Not Valid Access Code for this operation", "2023-01-24T11:57:36.0537863801", "...")
 
   def invalidGrnError(grn: GuaranteeReferenceNumber) =
     RequestErrorResponse(s"Guarantee not found for GRN: ${grn.value}", "2023-01-24T11:57:36.0537863801", "...")
+
+  val invalidTypeError =
+    RequestErrorResponse("Not Valid Guarantee Type for this operation", "2023-01-24T11:57:36.0537863801", "...")
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -72,11 +72,6 @@ controllers {
   # 300 is the default, you may need to change this according to your needs
   confidenceLevel = 300
 
-  uk.gov.hmrc.ctcguaranteebalanceeisstub.controllers.MicroserviceHelloWorldController = {
-    needsAuth = false
-    needsLogging = false
-    needsAuditing = false
-  }
 }
 
 # Metrics plugin settings - graphite reporting is configured on a per env basis
@@ -92,8 +87,7 @@ metrics {
 # Microservice specific config
 
 auditing {
-  enabled = true
-  traceRequests = true
+  enabled = false
   consumer {
     baseUri {
       host = localhost

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,9 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc"    %% "bootstrap-test-play-28" % bootstrapVersion,
-    "org.scalacheck" %% "scalacheck"             % "1.17.0"
+    "uk.gov.hmrc"         %% "bootstrap-test-play-28" % bootstrapVersion,
+    "org.scalacheck"      %% "scalacheck"             % "1.17.0",
+    "org.scalatestplus"   %% "scalacheck-1-17"        % "3.2.17.0",
+    "com.vladsch.flexmark" % "flexmark-all"            % "0.62.2"
   ).map(_ % "test, it")
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,8 +2,8 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.8.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.13.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.2.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"         % "2.8.20")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "1.9.3")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.3")

--- a/test/uk/gov/hmrc/ctcguaranteebalanceeisstub/controllers/Generators.scala
+++ b/test/uk/gov/hmrc/ctcguaranteebalanceeisstub/controllers/Generators.scala
@@ -19,23 +19,31 @@ package uk.gov.hmrc.ctcguaranteebalanceeisstub.controllers
 import org.scalacheck.Gen
 import uk.gov.hmrc.ctcguaranteebalanceeisstub.models.AccessCode
 import uk.gov.hmrc.ctcguaranteebalanceeisstub.models.GuaranteeReferenceNumber
-import uk.gov.hmrc.ctcguaranteebalanceeisstub.models.requests.AccessCodeRequest
 import uk.gov.hmrc.ctcguaranteebalanceeisstub.models.responses.AccessCodeResponse
 import uk.gov.hmrc.ctcguaranteebalanceeisstub.models.responses.BalanceResponse
 
 trait Generators {
 
   val balanceResponseGenerator: Gen[BalanceResponse] = for {
-    grn <- guaranteeReferenceNumberGenerator
+    grn <- guaranteeReferenceNumberGenerator()
   } yield BalanceResponse(grn, BalanceResponse.constantBalanceValue)
 
   val accessCodeResponseGenerator: Gen[AccessCodeResponse] = for {
-    grn <- guaranteeReferenceNumberGenerator
+    grn <- guaranteeReferenceNumberGenerator()
   } yield AccessCodeResponse(grn, AccessCode.constantAccessCodeValue)
 
-  def guaranteeReferenceNumberGenerator: Gen[GuaranteeReferenceNumber] =
+  val invalidGrnGenerator: Gen[GuaranteeReferenceNumber] =
+    guaranteeReferenceNumberGenerator(Gen.choose(10, 19).map(_.toString))
+
+  val invalidGrnTypeGenerator: Gen[GuaranteeReferenceNumber] =
+    guaranteeReferenceNumberGenerator(Gen.oneOf("02", "04"))
+
+  val invalidAccessCode: Gen[AccessCode] =
+    Gen.stringOfN(4, Gen.alphaUpperChar).map(AccessCode.apply)
+
+  def guaranteeReferenceNumberGenerator(yearGen: Gen[String] = Gen.choose(23, 39).map(_.toString)): Gen[GuaranteeReferenceNumber] =
     for {
-      year     <- Gen.choose(23, 39).map(_.toString)
+      year     <- yearGen
       country  <- Gen.oneOf("GB", "XI")
       alphanum <- Gen.stringOfN(12, Gen.alphaNumChar).map(_.toUpperCase)
       num1     <- Gen.numChar.map(_.toString)


### PR DESCRIPTION
GRNs starting `02` or `04` will be counted as invalid types (mirroring type 2 and type 4, though they are the same at the moment)